### PR TITLE
Update Node.js version from 20 to 24 in action.yml

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - uses: JarvusInnovations/background-action@v1
         with:
           run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
     - run: npm install
     - uses: ./
       with:

--- a/.holo/branches/github-action.lenses/build.toml
+++ b/.holo/branches/github-action.lenses/build.toml
@@ -1,5 +1,5 @@
 [hololens]
-package = "holo/lens-npm-run/20"
+package = "holo/lens-npm-run/24"
 
 [hololens.npm_run]
 env = "development"

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
     default: true
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
   post: 'index.js'


### PR DESCRIPTION
To remove warning: Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026